### PR TITLE
Revert "Update: Setting java environment on gradlew"

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -16,9 +16,6 @@ set APP_HOME=%DIRNAME%
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS=
 
-SET "JAVA_HOME=D:\java\zulu1.8.0_265\jre"
-echo Set Java Home to JAVA_HOME
-
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
 


### PR DESCRIPTION
This reverts commit edb2f77f5d9861e7bef5dc50b5ac6005594f7479.

* JAVA_HOME should never be a constant
* manual changes shall not be done to a generated file, as next regeneration of the wrapper will override the changes
* ./gradlew file was not changed anyway, so ./gradlew and ./gradlew.bat were out of sync